### PR TITLE
ActualReportBase.find method now takes two params

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,12 +14,43 @@
  * @link      http://developers.mobileapptracking.com @endlink
  */
 
-var convict = require("convict");
+var
+  fs = require("fs"),
+  path = require("path"),
+  convict = require("convict");
+
+/**
+ * load a config file if the configFile exists in given path
+ *
+ * @param  convict c         convict config isntance
+ * @param  string configPath check if the given configPath exists.
+ *
+ * @return {Boolean}
+ */
+var loadConfigFile = function (c, configPath) {
+  if (fs.existsSync(configPath)) {
+    c.loadFile(configPath);
+    return true;
+  }
+
+  var newPath = path.join(__dirname, configPath);
+  if (fs.existsSync(configPath)) {
+    c.loadFile(newPath);
+    return true;
+  }
+
+  return false;
+};
+
 
 var config = convict({
   env: {
     doc: "TUNE Reporting SDK environment.",
-    format: ["production", "development", "test"],
+    format: function (val) {
+      if (!/(^prod|^test|^dev|^stage)/.test(val)) {
+        throw new Error('Should be sensible environment value');
+      }
+    },
     default: "development",
     env: "NODE_ENV",
     arg: "env"
@@ -69,8 +100,11 @@ var config = convict({
   }
 });
 
-// load environment dependent configuration
-config.loadFile("./config/" + config.get("env") + ".json");
+// load environment dependent configurationk
+loadConfigFile(
+  config,
+  path.join("./config/", config.get("env") + ".json")
+);
 
 // validate
 config.validate();

--- a/lib/base/endpoints/AdvertiserReportActualsBase.js
+++ b/lib/base/endpoints/AdvertiserReportActualsBase.js
@@ -194,60 +194,43 @@ AdvertiserReportActualsBase.prototype.count = function (
  * @uses TuneManagementResponse
  */
 AdvertiserReportActualsBase.prototype.find = function (
-  startDate,
-  endDate,
-  fields,
-  group,
-  filter,
-  limit,
-  page,
-  sort,
-  timestamp,
-  strResponseTimezone,
+  options,
   callback
 ) {
+
   // Required parameters
-  this.validateDateTime('start_date', startDate);
-  this.validateDateTime('end_date', endDate);
+  this.validateDateTime('start_date', options.startDate);
+  this.validateDateTime('end_date', options.endDate);
 
   // Optional parameters
-  if (fields) {
-    fields = this.validateFields(fields);
-  }
-  if (group) {
-    group = this.validateGroup(group);
-  }
-  if (filter) {
-    filter = this.validateFilter(filter);
-  }
-  if (limit) {
-    limit = this.validateLimit(limit);
-  }
-  if (page) {
-    page = this.validatePage(page);
-  }
-  if (sort) {
-    sort = this.validateSort(sort);
-  }
-  if (timestamp) {
-    timestamp = this.validateTimestamp(timestamp);
-  }
-  if (strResponseTimezone) {
-    strResponseTimezone = this.validateResponseTimezone(strResponseTimezone);
-  }
+  this.validateOptionalParams(
+    options,
+    [
+      'fields',
+      'group',
+      'filter',
+      'limit',
+      'page',
+      'sort',
+      'timestamp',
+      'responseTimezone'
+    ]
+  );
 
   var
     mapQueryString = {
-      'start_date': startDate,
-      'end_date': endDate,
-      'fields': fields,
-      'group': group,
-      'filter': filter,
-      'limit': limit,
-      'page': page,
-      'sort': sort,
-      'timestamp': timestamp,
-      'response_timezone': strResponseTimezone
+      'start_date': options.startDate,
+      'end_date': options.endDate,
+      'fields': options.fields,
+      'group': options.group,
+      'filter': options.filter,
+      'limit': options.limit,
+      'page': options.page,
+      'sort': options.sort,
+      'timestamp': options.timestamp,
+      'response_timezone': options.responseTimezone,
+      'session_token': options.sessionToken,
+      'api_key': options.apiKey
     },
     reportRequest = this.getReportRequest(
       'find',

--- a/lib/base/endpoints/EndpointBase.js
+++ b/lib/base/endpoints/EndpointBase.js
@@ -981,6 +981,42 @@ EndpointBase.prototype.validateDateTime = function (paramName, dateTime) {
 };
 
 /**
+ * Validates given fieldNames of options object
+ * @param  object options      options object to be veirified
+ * @param  Array paramNames    paramNames to be validated
+ *
+ * @return {Boolean}
+ * @throws InvalidArgument
+ */
+EndpointBase.prototype.validateOptionalParams = function (options, paramNames) {
+  if (typeof options === 'undefined' || options === null) {
+    throw new InvalidArgument(
+      'options object cannot be empty'
+    );
+  }
+  var self = this;
+  _.forEach(paramNames, function (paramName) {
+    if (options[paramName]) {
+      switch (paramName) {
+      case 'startDate':
+        self.validateDateTime('start_date', options[paramName]);
+        break;
+      case 'endDate':
+        self.validateDateTime('end_date', options[paramName]);
+        break;
+      default:
+        var validateFuncName = 'validate' + paramName.charAt(0).toUpperCase() + paramName.slice(1);
+        var validateFunc = self[validateFuncName];
+        if (validateFunc && typeof validateFunc === 'function') {
+          options[paramName] = validateFunc.call(self, options[paramName]);
+        }
+      }
+    }
+  });
+  return true;
+};
+
+/**
  * Helper function for fetching report document given provided job identifier.
  *
  * Requesting for report url is not the same for all report endpoints.

--- a/lib/base/service/TuneManagementRequest.js
+++ b/lib/base/service/TuneManagementRequest.js
@@ -189,8 +189,14 @@ TuneManagementRequest.prototype.getTuneManagementQueryString = function () {
   tuneQueryString.add('sdk', TuneManagementRequest.SDK_NAME);
   tuneQueryString.add('ver', TuneManagementRequest.SDK_VERSION);
 
-  if (this.authKey && this.authType) {
-    tuneQueryString.add(this.authType, this.authKey);
+  if (!_.isEmpty(this.mapQueryString.session_token)
+      && !_.isEmpty(this.mapQueryString.api_key)) {
+    delete this.mapQueryString.api_key;
+  } else if (_.isEmpty(this.mapQueryString.session_token)
+             && _.isEmpty(this.mapQueryString.api_key)) {
+    if (this.authKey && this.authType) {
+      tuneQueryString.add(this.authType, this.authKey);
+    }
   }
 
   // Build query string with provided contents in dictionary

--- a/test/TestAdvertiserReportActuals.js
+++ b/test/TestAdvertiserReportActuals.js
@@ -87,17 +87,21 @@ describe('test AdvertiserReportActuals', function () {
   });
 
   it('find', function (done) {
+    var options = {
+      startDate: startDate,
+      endDate: endDate,
+      fields: fieldsRecommended,
+      group: 'site_id,publisher_id',                         // group
+      filter: '(publisher_id > 0)',                           // filter
+      limit: 5,                                              // limit
+      page: null,                                           // page
+      sort: { 'paid_installs': 'DESC' },                    // sort
+      timestamp: 'datehour',                                     // timestamp
+      responseTimezone: strResponseTimezone,
+    }
+
     advertiserReport.find(
-      startDate,
-      endDate,
-      fieldsRecommended,                              // fields
-      'site_id,publisher_id',                         // group
-      '(publisher_id > 0)',                           // filter
-      5,                                              // limit
-      null,                                           // page
-      { 'paid_installs': 'DESC' },                    // sort
-      'datehour',                                     // timestamp
-      strResponseTimezone,
+      options,
       function (error, response) {
         expect(error).to.be.null;
         expect(response).to.be.not.null;


### PR DESCRIPTION
This pull request is to show example how to achieve 
`function (options, callback)` on API method call.

Note: 
- method change was made only on ActualReportBase
- new validation method `validateOptionalParams = function (options, paramNames)` is added
- config.js loads config file only if it exists.
- config.js now has more forgiving standard for `env` field
